### PR TITLE
Add secondary hash; avoid String round-trips

### DIFF
--- a/src/main/java/oamirror/Api.java
+++ b/src/main/java/oamirror/Api.java
@@ -4,8 +4,9 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 public class Api extends HttpServlet {
 
@@ -48,9 +49,7 @@ public class Api extends HttpServlet {
 
         if (!available) {
             res.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
-            try (OutputStreamWriter out = new OutputStreamWriter(res.getOutputStream())) {
-                out.write("The index is unavailable.");
-            }
+            res.getOutputStream().write("The index is unavailable.".getBytes(StandardCharsets.UTF_8));
         } else {
             if (req.getPathInfo() != null) {
                 // We expect "/some:funky_doi"
@@ -58,15 +57,15 @@ public class Api extends HttpServlet {
                 while (doi.startsWith("/"))
                     doi = doi.substring(1);
 
-                String responseValue = index.getByDoi(doi);
+                byte[] responseValue = index.getByDoi(doi);
                 if (responseValue == null) {
                     res.setStatus(HttpServletResponse.SC_NOT_FOUND);
                 } else {
                     res.setStatus(HttpServletResponse.SC_OK);
                     res.setContentType("application/json");
-                    try (OutputStreamWriter out = new OutputStreamWriter(res.getOutputStream())) {
-                        out.write(responseValue);
-                    }
+                    res.setContentLength(responseValue.length);
+                    OutputStream out = res.getOutputStream();
+                    out.write(responseValue);
                 }
             } else {
                 res.setStatus(HttpServletResponse.SC_NOT_FOUND);

--- a/src/main/java/oamirror/Index.java
+++ b/src/main/java/oamirror/Index.java
@@ -43,18 +43,59 @@ public class Index {
     final String path;
     int indexCount = 0;
 
-    public String getByDoi(String doi) throws IOException {
+    // The fileNumber int does double duty: we use the 21 low bits for the actual file number,
+    // and the 11 high bits for a DOI "fingerprint" that we can compare when probing,
+    // so we can reject candidates without having to fetch from DISK and parse JSON.
+    // 21 bits for fileNumber means a max of 2097151 files. Current Crossref dump has ~1.3M files,
+    // so plenty of space still. If we ever need more we'd also have to increase tableSize anyway
+    // (meaning reindex) and could give another bit to file number and one fewer to the fingerprint
+    // and still be fine.
+    static final int FILE_NUMBER_BITS = 21;
+    static final int FILE_NUMBER_MASK = (1 << FILE_NUMBER_BITS) - 1;
+    static final int MAX_FILE_NUMBER = FILE_NUMBER_MASK;
+    static final int FINGERPRINT_BITS = 32 - FILE_NUMBER_BITS; // 11
+    static final int FINGERPRINT_MASK = (1 << FINGERPRINT_BITS) - 1;
+
+    /**
+     * Secondary hash independent of String.hashCode(), used as a fingerprint stored alongside
+     * each slot. We multiply-mix the chars with a different multiplier (33 vs hashCode's 31) and
+     * a finalisation step, so a chain that clusters under hashCode() does NOT also cluster
+     * under this function.
+     */
+    static int fingerprintFor(String doi) {
+        int h = 0;
+        for (int i = 0; i < doi.length(); ++i) {
+            h = h * 33 + doi.charAt(i);
+        }
+        // Based on:
+        // https://nullprogram.com/blog/2018/07/31/#update-after-one-week
+        // https://github.com/skeeto/hash-prospector (public domain)
+        h ^= h >>> 16;
+        h *= 0x7feb352d;
+        h ^= h >>> 15;
+        int fp = h & FINGERPRINT_MASK;
+        return fp == 0 ? 1 : fp;
+    }
+
+    public byte[] getByDoi(String doi) throws IOException {
         int hash = Math.abs(doi.hashCode());
         int tableIndex = hash % (tableSize / 2);
+        int expectedFp = fingerprintFor(doi);
 
         int linearProbe = 0;
-        while ( table[ ((tableIndex + linearProbe) * 2 + 0) % tableSize ] != 0 ) {
-            int fileNumber = table[ ((tableIndex + linearProbe) * 2 + 0) % tableSize ];
-            int offset = table[ ((tableIndex + linearProbe) * 2 + 1) % tableSize ];
+        int packed;
+        while ( (packed = table[ ((tableIndex + linearProbe) * 2 + 0) % tableSize ]) != 0 ) {
             ++linearProbe;
 
-            // If this is the one, return it!
-            String entry = getEntryAt(fileNumber, offset);
+            // Memory-only fingerprint check: rejects ~2047/2048 of unrelated DOIs sharing
+            // this cluster without touching disk.
+            int slotFp = (packed >>> FILE_NUMBER_BITS) & FINGERPRINT_MASK;
+            if (slotFp != expectedFp) continue;
+
+            int fileNumber = packed & FILE_NUMBER_MASK;
+            int offset = table[ ((tableIndex + linearProbe - 1) * 2 + 1) % tableSize ];
+
+            byte[] entry = getEntryAt(fileNumber, offset);
             Map json = mapper.readValue(entry, HashMap.class);
             String candidateDoi = (String) json.get("doi");
             if (candidateDoi.equals(doi))
@@ -81,7 +122,7 @@ public class Index {
         }
     }
 
-    private String getEntryAt(int fileNumber, int offset) throws IOException {
+    private byte[] getEntryAt(int fileNumber, int offset) throws IOException {
         String fileName = String.format("%08d.gz", fileNumber);
         try (GZIPInputStream in = new GZIPInputStream(
                 new BufferedInputStream(new FileInputStream(path+"/"+fileName)))) {
@@ -93,17 +134,21 @@ public class Index {
                 for (int i = 0; i < n; ++i) {
                     if (buf[i] == 10) { // terminate on LF
                         entry.write(buf, 0, i);
-                        return entry.toString(StandardCharsets.UTF_8);
+                        return entry.toByteArray();
                     }
                 }
                 entry.write(buf, 0, n);
             }
-            return entry.toString(StandardCharsets.UTF_8); // last entry (EOF)
+            return entry.toByteArray(); // last entry (EOF)
         }
     }
 
     private void indexFile(File file) throws IOException {
         int fileNumber = Integer.parseInt(file.getName().substring(0, 8));
+        if (fileNumber <= 0 || fileNumber > MAX_FILE_NUMBER) {
+            throw new IOException("File number " + fileNumber + " from " + file.getName()
+                    + " is out of range [1, " + MAX_FILE_NUMBER + "]; bump FILE_NUMBER_BITS.");
+        }
         try (GZIPInputStream in = new GZIPInputStream(new FileInputStream(file))) {
             byte[] data = in.readAllBytes();
 
@@ -119,11 +164,13 @@ public class Index {
                     int hash = Math.abs(doi.hashCode());
                     int tableIndex = hash % (tableSize / 2);
                     int offset = entryBeginsAt;
+                    int fp = fingerprintFor(doi);
+                    int packed = (fp << FILE_NUMBER_BITS) | fileNumber;
                     int linearProbe = 0;
                     while ( table[ ((tableIndex + linearProbe) * 2 + 0) % tableSize ] != 0 ) {
                         ++linearProbe;
                     }
-                    table[ ((tableIndex + linearProbe) * 2 + 0) % tableSize ] = fileNumber;
+                    table[ ((tableIndex + linearProbe) * 2 + 0) % tableSize ] = packed;
                     table[ ((tableIndex + linearProbe) * 2 + 1) % tableSize ] = offset;
 
                     ++indexCount;
@@ -141,12 +188,10 @@ public class Index {
     private void writeIndexToFile() throws IOException {
         System.err.println("Writing index to: " + path + "/index ..");
 
-        try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(path+"/index"))) {
-            ByteBuffer buf = ByteBuffer.allocate(4);
+        try (DataOutputStream out = new DataOutputStream(
+                new BufferedOutputStream(new FileOutputStream(path+"/index"), 1 << 20))) {
             for (int i = 0; i < tableSize; ++i) {
-                buf.putInt(table[i]);
-                buf.clear(); // sigh
-                out.write(buf.array());
+                out.writeInt(table[i]);
             }
         }
 
@@ -162,13 +207,10 @@ public class Index {
 
         System.err.println("Loading index from: " + path + "/index ..");
 
-        byte[] b = new byte[4];
-        ByteBuffer buf = ByteBuffer.wrap(b);
-        try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(f))) {
+        try (DataInputStream in = new DataInputStream(
+                new BufferedInputStream(new FileInputStream(f), 1 << 20))) {
             for (int i = 0; i < tableSize; ++i) {
-                buf.clear();
-                in.readNBytes(b, 0, 4);
-                table[i] = buf.getInt();
+                table[i] = in.readInt();
             }
         }
 


### PR DESCRIPTION
#3 helped performance but there were still hundreds of records that the Swepub harvester workers failed to fetch, even after multiple attempts on each. I took a closer look at the failed ones and realized that these failed because of an entirely different problem.

For example, http://oamirror.libris.kb.se:8080/works/10.1016/j.jhazmat.2021.125626 took more than 50+ seconds to fetch _even when load on the server was near zero_, every time. (Currently that URL is fine because I deployed this code to test it.)

I added some debug code to `getByDoi()` and it turned out that for this particular record, it took 24876 probe steps to find the right record. Meaning it had to open 24876 files (and for each file decompress and parse JSON) just to find that one DOI. Which explains why it took a while.

I let kladde (Claude) write a quick stats tool and it turned out that about 4.5 million (2.7%) of all Crossref DOIs hade a probe chain of >1000 (while for Unpaywall it was 353k / 0.27%).

So, with the help of kladde (again) - I wasn't clever enough to come up with the idea all by myself - I added a secondary hash, packed into the high bits of the existing `fileNumber` int, so we can discard most candidates without having to read the files.

This way, in the worst-case scenario, the number of fileread-decompress-parse-JSON is reduced from ~25k to 30, with zero extra memory cost. (And the average number of file reads for a DOI is also massively reduced.)

So, http://oamirror.libris.kb.se:8080/works/10.1016/j.jhazmat.2021.125626 now takes ~80-100ms to fetch instead of 50+ seconds.

The other (smaller) change is that `getByDoi`  and `getEntryAt` now return `byte[]` instead of `String`, and `Api.doGet` writes the raw bytes, to avoid some unnecessary decoding/reencoding (the Crossref/Unpaywall data is already UTF-8).

Another data point is that on oamirror, while doing a full Swepub reindex, load average is now consistently around 0.4-0.5 (as opposed to 20-60 before).